### PR TITLE
feat: add lazy loading for images

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
         </div>
       </div>
       <p class="text-muted" id="post-meta"></p>
-      <img id="post-cover" alt="" class="img-fluid rounded mb-3" />
+      <img id="post-cover" alt="" class="img-fluid rounded mb-3" loading="lazy" />
       <article id="post-content" class="mb-4"></article>
 
       <section id="comments" aria-labelledby="comments-title" class="card p-3">

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -128,7 +128,7 @@ async function renderList() {
       return `
       <article class="col-md-6">
         <div class="card h-100">
-          <img class="card-img-top" src="${a.cover}" alt="${escapeHtml(a.title)}封面">
+          <img class="card-img-top" src="${a.cover}" alt="${escapeHtml(a.title)}封面" loading="lazy">
           <div class="card-body">
             <h3 class="h5 card-title">${title}</h3>
             <p class="card-text">${excerpt}</p>
@@ -240,6 +240,9 @@ function initCommentForm(slug) {
 // 内容格式化
 function normalizeArticleHtml(article) {
   let html = article.contentHtml || "";
+  if (html) {
+    html = html.replace(/<img(?![^>]*loading=)([^>]*)>/gi, '<img loading="lazy"$1>');
+  }
   let pCount = (html.match(/<\/p>/gi) || []).length;
   if (pCount > 1 || /<(h\d|ul|ol|pre|blockquote|table|figure|img)\b/i.test(html)) return html;
   let text = html.replace(/^<p>/i, "").replace(/<\/p>$/i, "");


### PR DESCRIPTION
## Summary
- add `loading="lazy"` to post cover and article list images
- automatically inject `loading="lazy"` for inline images in post content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aef55c55d4832e925a1ac9af14b1a7